### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mach"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>", "David Cuddeback <david.cuddeback@gmail.com>"]
 
 license = "BSD-2-Clause"


### PR DESCRIPTION
Would be great if the last commit was available in published version so that dependent crates can use it.

Sorry if it's not the preferred method to propose a version update.